### PR TITLE
TagLL needs a public API to allow TagClusterReducer implementations

### DIFF
--- a/src/main/java/org/opensextant/solrtexttagger/TagLL.java
+++ b/src/main/java/org/opensextant/solrtexttagger/TagLL.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  *
  * @author David Smiley - dsmiley@mitre.org
  */
-class TagLL{
+public class TagLL{
 
   private final TagLL[] head;//a shared pointer to the head; 1 element
   TagLL prevTag, nextTag; // linked list
@@ -105,7 +105,7 @@ class TagLL{
 
   /** Removes this tag from the chain, connecting prevTag and nextTag. Does not modify "this" object's pointers,
    * so the caller can refer to nextTag after removing it. */
-  void removeLL() {
+  public void removeLL() {
     if (head[0] == this)
       head[0] = nextTag;
     if (prevTag != null) {
@@ -141,11 +141,25 @@ class TagLL{
     tag.prevTag = this;
   }
 
-  int charLen() {
+  public int charLen() {
     return endOffset - startOffset;
   }
 
-  boolean overlaps(TagLL other) {
+  public TagLL getNextTag() {
+    return nextTag;
+  }
+  
+  public TagLL getPrevTag() {
+    return prevTag;
+  }
+  
+  public int getStartOffset() {
+    return startOffset;
+  }
+  public int getEndOffset() {
+    return endOffset;
+  }
+  public boolean overlaps(TagLL other) {
     //don't use >= or <= because startOffset is inclusive while endOffset is exclusive
     if (startOffset < other.startOffset)
       return endOffset > other.startOffset;


### PR DESCRIPTION
While implementing a TagClusterReducer that removes Tags that do not overlap proper-nouns I noticed that one can not have own TagClusterReducer implementations because TagLL (used by the Interface) is not a public class and does not define a public API.

This pull requests makes TagLL public and adds an public API sufficient for implementing TagClusterReducer.

Summary of changes:
- changed class from default to public
- added public getter for properties needed by TagClusterReducer implementations
- changed removeLL() method from default to public as TagClusterReducer need to be able to reduce tags
