### PR TITLE
Porting solr text tagger to Lucene/Solr 5.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,9 @@ language: java
 script: mvn -Drandomized.multiplier=10 -Dsolr.version=$SOLR_VERSION -Dlog.level=WARN clean verify
 
 jdk:
-  - openjdk6
+  - openjdk7
 env:
-  - SOLR_VERSION=4.7.2
-  - SOLR_VERSION=4.6.1
-  - SOLR_VERSION=4.5.1
-  - SOLR_VERSION=4.4.0
-  - SOLR_VERSION=4.3.1
-
-matrix:
-  include:
-    - jdk: openjdk7
-      env: SOLR_VERSION=4.8.1
-  include:
-    - jdk: openjdk7
-      env: SOLR_VERSION=4.9.1
-  include:
-    - jdk: openjdk7
-      env: SOLR_VERSION=4.10.3
+  - SOLR_VERSION=5.0.0
 
 notifications:
   email:

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- tests pass with many other versions; see .travis.yml.  -->
-    <solr.version>4.10.3</solr.version>
+    <!--
+     For solr 4.x compatability see version 2.0, tag: solr-text-tagger-2.0
+    -->
+    <solr.version>5.0.0</solr.version>
   </properties>
 
   <prerequisites>

--- a/src/test/java/org/opensextant/solrtexttagger/ConcatenateFilterTest.java
+++ b/src/test/java/org/opensextant/solrtexttagger/ConcatenateFilterTest.java
@@ -33,7 +33,8 @@ public class ConcatenateFilterTest extends BaseTokenStreamTestCase {
 
   public void testTypical() throws IOException {
     String NYC = "new york city";
-    TokenStream stream = new WhitespaceTokenizer(TEST_VERSION_CURRENT, new StringReader(NYC));
+    WhitespaceTokenizer stream = new WhitespaceTokenizer();
+    stream.setReader(new StringReader(NYC));
     ConcatenateFilter filter = new ConcatenateFilter(stream);
     try {
       assertTokenStreamContents(filter, new String[]{NYC},

--- a/src/test/java/org/opensextant/solrtexttagger/EmbeddedSolrNoSerializeTest.java
+++ b/src/test/java/org/opensextant/solrtexttagger/EmbeddedSolrNoSerializeTest.java
@@ -56,7 +56,7 @@ public class EmbeddedSolrNoSerializeTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void init() throws Exception {
     initCore("solrconfig.xml", "schema.xml");
-    solrServer = new EmbeddedSolrServer(h.getCoreContainer(), null);
+    solrServer = new EmbeddedSolrServer(h.getCoreContainer(), "collection1");
     //we don't need to close the EmbeddedSolrServer because SolrTestCaseJ4 closes the core
   }
 

--- a/src/test/java/org/opensextant/solrtexttagger/XmlInterpolationTest.java
+++ b/src/test/java/org/opensextant/solrtexttagger/XmlInterpolationTest.java
@@ -153,10 +153,12 @@ public class XmlInterpolationTest extends AbstractTaggerTest {
     int[] result = {-1, -1};
 
     Reader filter = new HTMLStripCharFilter(new StringReader(docText));
-    TokenStream ts = new WhitespaceTokenizer(LuceneTestCase.TEST_VERSION_CURRENT, filter);
+
+    WhitespaceTokenizer ts = new WhitespaceTokenizer();
     final CharTermAttribute termAttribute = ts.addAttribute(CharTermAttribute.class);
     final OffsetAttribute offsetAttribute = ts.addAttribute(OffsetAttribute.class);
     try {
+      ts.setReader(filter);
       ts.reset();
       while (ts.incrementToken()) {
         final String termString = termAttribute.toString();
@@ -181,9 +183,10 @@ public class XmlInterpolationTest extends AbstractTaggerTest {
 
     Reader filter = new HTMLStripCharFilter(new StringReader(docText),
             Collections.singleton("unescaped"));
-    TokenStream ts = new WhitespaceTokenizer(LuceneTestCase.TEST_VERSION_CURRENT, filter);
+    WhitespaceTokenizer ts = new WhitespaceTokenizer();
     final CharTermAttribute termAttribute = ts.addAttribute(CharTermAttribute.class);
     try {
+      ts.setReader(filter);
       ts.reset();
       while (ts.incrementToken()) {
         result.add(termAttribute.toString());

--- a/src/test/resources/solr/collection1/conf/schema.xml
+++ b/src/test/resources/solr/collection1/conf/schema.xml
@@ -72,7 +72,7 @@
         <tokenizer class="solr.StandardTokenizerFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" enablePositionIncrements="true" /><!-- by default english stopwords -->
+        <filter class="solr.StopFilterFactory" /><!-- by default english stopwords -->
 
         <filter class="org.opensextant.solrtexttagger.ConcatenateFilterFactory" />
       </analyzer>
@@ -80,7 +80,7 @@
         <tokenizer class="solr.StandardTokenizerFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" enablePositionIncrements="true" /><!-- by default english stopwords -->
+        <filter class="solr.StopFilterFactory" /><!-- by default english stopwords -->
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
This updates the module to the soon to be released solr 5.0. I built it against the lucene_solr_5_0_0 tag in the solr svn repo. Unit tests pass and smoke testing in a running solr 5.x instance works well. 

I am not sure what the strategy for tracking upstream solr versions in this repo is, whether this should be on master or perhaps another branch.  If it is preferred for this to go into a branch I'm happy to rework as necessary. 