### PR TITLE
Upgrade Solr to `6.1.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
      For Solr 5.2,              use tagger version 2.2, tag: solr-text-tagger-2.2
      For Solr 6.1               use tagger version 2.3-SNAPSHOT
     -->
-    <solr.version>6.1.0</solr.version>
+    <solr.version>5.4.0</solr.version>
   </properties>
 
   <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
      For Solr 5.0 - 5.1,        use tagger version 2.1, tag: solr-text-tagger-2.1
      For Solr 5.2,              use tagger version 2.2, tag: solr-text-tagger-2.2
     -->
-    <solr.version>5.4.0</solr.version>
+    <solr.version>6.1.0</solr.version>
   </properties>
 
   <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
      For Solr 4.x compatability use tagger version 2.0, tag: solr-text-tagger-2.0
      For Solr 5.0 - 5.1,        use tagger version 2.1, tag: solr-text-tagger-2.1
      For Solr 5.2,              use tagger version 2.2, tag: solr-text-tagger-2.2
+     For Solr 6.1               use tagger version 2.3-SNAPSHOT
     -->
     <solr.version>6.1.0</solr.version>
   </properties>

--- a/src/main/java/org/opensextant/solrtexttagger/TaggingAttributeImpl.java
+++ b/src/main/java/org/opensextant/solrtexttagger/TaggingAttributeImpl.java
@@ -23,6 +23,7 @@
 package org.opensextant.solrtexttagger;
 
 import org.apache.lucene.util.AttributeImpl;
+import org.apache.lucene.util.AttributeReflector;
 
 /**
  * Implementation of the {@link TaggingAttribute}
@@ -70,6 +71,11 @@ public class TaggingAttributeImpl extends AttributeImpl implements TaggingAttrib
   @Override
   public void copyTo(AttributeImpl target) {
     ((TaggingAttribute) target).setTaggable(taggable);
+  }
+
+  @Override
+  public void reflectWith(AttributeReflector reflector) {
+    reflector.reflect(TaggingAttribute.class, "taggable", isTaggable());
   }
 
 }


### PR DESCRIPTION
Updated to Solr 6.1.0 after getting 

    java.lang.NoSuchMethodError: org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute.fillBytesRef()V

with the 2.2 release while using Solr 6.1.0