### PR TITLE
Support for handling multiple filter queries, #37.

### DIFF
--- a/src/main/java/org/opensextant/solrtexttagger/TaggerRequestHandler.java
+++ b/src/main/java/org/opensextant/solrtexttagger/TaggerRequestHandler.java
@@ -307,18 +307,21 @@ public class TaggerRequestHandler extends RequestHandlerBase {
    * either. If null is returned, then all docs are available.
    */
   private Bits computeDocCorpus(SolrQueryRequest req) throws SyntaxError, IOException {
-    final String corpusFilterQuery = req.getParams().get("fq");
+    final String[] corpusFilterQueries = req.getParams().getParams("fq");
     final SolrIndexSearcher searcher = req.getSearcher();
     final Bits docBits;
-    if (corpusFilterQuery != null) {
-      QParser qParser = QParser.getParser(corpusFilterQuery, null, req);
-      Query filterQuery;
-      try {
-        filterQuery = qParser.parse();
-      } catch (SyntaxError e) {
-        throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e);
+    if (corpusFilterQueries != null && corpusFilterQueries.length > 0) {
+      List<Query> filterQueries = new ArrayList<Query>(corpusFilterQueries.length);
+      for (String corpusFilterQuery : corpusFilterQueries) {
+        QParser qParser = QParser.getParser(corpusFilterQuery, null, req);
+        try {
+          filterQueries.add(qParser.parse());
+        } catch (SyntaxError e) {
+          throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e);
+        }
       }
-      final DocSet docSet = searcher.getDocSet(filterQuery);//hopefully in the cache
+
+      final DocSet docSet = searcher.getDocSet(filterQueries);//hopefully in the cache
       //note: before Solr 4.7 we could call docSet.getBits() but no longer.
       if (docSet instanceof BitDocSet) {
         docBits = ((BitDocSet)docSet).getBits();

--- a/src/test/java/org/opensextant/solrtexttagger/AbstractTaggerTest.java
+++ b/src/test/java/org/opensextant/solrtexttagger/AbstractTaggerTest.java
@@ -171,8 +171,13 @@ public abstract class AbstractTaggerTest extends SolrTestCaseJ4 {
 
   /** REMEMBER to close() the result req object. */
   protected SolrQueryRequest reqDoc(String doc, String... moreParams) {
+    return reqDoc(doc, params(moreParams));
+  }
+
+  /** REMEMBER to close() the result req object. */
+  protected SolrQueryRequest reqDoc(String doc, SolrParams moreParams) {
     log.debug("Test doc: "+doc);
-    SolrParams params = SolrParams.wrapDefaults(params(moreParams), baseParams);
+    SolrParams params = SolrParams.wrapDefaults(moreParams, baseParams);
     SolrQueryRequestBase req = new SolrQueryRequestBase(h.getCore(), params) {};
     Iterable<ContentStream> stream = Collections.singleton((ContentStream)new ContentStreamBase.StringStream(doc));
     req.setContentStreams(stream);

--- a/src/test/java/org/opensextant/solrtexttagger/TaggerTest.java
+++ b/src/test/java/org/opensextant/solrtexttagger/TaggerTest.java
@@ -22,9 +22,14 @@
 
 package org.opensextant.solrtexttagger;
 
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * The original test for {@link org.opensextant.solrtexttagger.TaggerRequestHandler}.
@@ -224,7 +229,49 @@ public class TaggerTest extends AbstractTaggerTest {
         tt(doc, "City of London", 0, N.City_of_London),
         tt(doc, "London", 0, N.London));
   }
-  
+
+  @Test
+  public void testMultipleFilterQueries() throws Exception {
+    baseParams.set("qt", "/tag");
+    baseParams.set("overlaps", "ALL");
+
+    // build up the corpus with some additional fields for filtering purposes
+    deleteByQueryAndGetVersion("*:*", null);
+
+    int i = 0;
+    assertU(adoc("id", ""+i++, "name", N.London.getName(), "type", "city", "country", "UK"));
+    assertU(adoc("id", ""+i++, "name", N.London_Business_School.getName(), "type", "school", "country", "UK"));
+    assertU(adoc("id", ""+i++, "name", N.Boston.getName(), "type", "city", "country", "US"));
+    assertU(adoc("id", ""+i++, "name", N.City_of_London.getName(), "type", "org", "country", "UK"));
+    assertU(commit());
+
+    // not calling buildNames so that we can bring along extra attributes for filtering
+    NAMES = Arrays.stream(N.values()).map(N::getName).collect(Collectors.toList());
+
+    // phrase that matches everything
+    String doc = "City of London Business School in Boston";
+
+    // first do no filtering
+    ModifiableSolrParams p = new ModifiableSolrParams();
+    p.add(CommonParams.Q, "*:*");
+    assertTags(reqDoc(doc, p),
+        tt(doc, "City of London", 0, N.City_of_London),
+        tt(doc, "London", 0, N.London),
+        tt(doc, "London Business School", 0, N.London_Business_School),
+        tt(doc, "Boston", 0, N.Boston));
+
+    // add a single fq
+    p.add(CommonParams.FQ, "type:city");
+    assertTags(reqDoc(doc, p),
+        tt(doc, "London", 0, N.London),
+        tt(doc, "Boston", 0, N.Boston));
+
+    // add another fq
+    p.add(CommonParams.FQ, "country:US");
+    assertTags(reqDoc(doc, p),
+        tt(doc, "Boston", 0, N.Boston));
+  }
+
   private TestTag tt(String doc, String substring, int substringIndex, N name) {
     assert substringIndex == 0;
 


### PR DESCRIPTION
Updates computeDocCorpus to accept multiple "fq" parameters. Useful when using fq in defaults and appends parameters. 