### PR TITLE
Changes for Solr 6.3.0 compatibility (#60 and #63)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
      For Solr 4.x comparability use tagger version 2.0, tag: solr-text-tagger-2.0
      For Solr 5.0 - 5.1,        use tagger version 2.1, tag: solr-text-tagger-2.1
      For Solr 5.2,              use tagger version 2.2, tag: solr-text-tagger-2.2
-     For Solr 5.3 - 6x?...      use tagger version 2.3, tag: solr-text-tagger-2.3
-     For Solr 6.x               use tagger version 2.3-SNAPSHOT
+     For Solr 5.3 - 6.2.1       use tagger version 2.3, tag: solr-text-tagger-2.3
+     For Solr 6.3               use tagger version 2.4-SNAPSHOT
     -->
     <solr.version>6.1.0</solr.version>
   </properties>


### PR DESCRIPTION
* The TaggerRequestHandler now uses reflection to account for the API change of SOLR-9592
* The RandomizedTaggerTest uses reflection to account for a API change in a dependency of the Solr Test framework

This allows the same code (runtime and test) to be used with any Lucene/Solr 6.x release and fix both #60 and #63 